### PR TITLE
Draft Privacy Statement

### DIFF
--- a/privacy-statement.md
+++ b/privacy-statement.md
@@ -1,0 +1,33 @@
+
+# Privacy Statement
+
+FoodWorks Madison is aware of online privacy issues and concerns. We make our privacy policy available so visitors to our site may feel free to provide personal information, knowing this information is not intended for misuse.
+
+## What personal information is collected?
+
+FoodWorks Madison has the capability of collecting various bits of information from you without your active participation (as you browse our site). Such information might include: IP address, browser type/version and computer platform. Your browser automatically submits this information in order to correctly fulfill page requests. 
+
+Like many websites, the FoodWorks Madison reserves the right to use "cookie" technology, including for Google Analytics. The cookies we use do not reveal any personally identifiable information about you. Cookies help us understand which parts of our website are the most popular, where our visitors are going, and how long they spend there. We use cookies to study traffic patterns on our site so we can make adjustments and improvements.
+
+FoodWorks Madison will not make any attempt to disaggregate the data provided by cookies and will not identify users or facilitate the merging of personally identifiable information with non-personally identifiable information. 
+
+To provide website visitors the ability to prevent their data from being used by Google Analytics, Google has developed the Google Analytics opt-out brower add-on. [More information can be found here](http://tools.google.com/dlpage/gaoptout/).
+
+
+## Why we collect your personal information
+
+In addition to the automatically collected information described above, we may ask you to voluntarily submit some personal information. FoodWorks Madison may do this for a variety of reasons, though in most cases this information will be used to directly contact you at your request. FoodWorks Madison will also collect information from you to promote your community initiatives.
+
+## Disclosure of personal information
+
+FoodWorks Madison will maintain all information submitted for its original intent. We will not share your personal information with another third-party without your express consent. All automatically and voluntarily submitted information may be maintained in our database. In all other cases, personal information is not kept in any form of a record. At times we may be required by law or legal process to disclose your personal information. We may also disclose information about you if we believe that disclosure is necessary for the public interest. FoodWorks Madison reserves the right to determine what cases warrant public interests.
+
+
+## How we protect your personal information
+
+FoodWorks Madison safeguards the security of the data you send us with physical, electronic, and managerial procedures.
+
+
+## Access to your personal information
+
+You have access to the personal information you voluntarily submit. We also may require all requests to be made in writing and for your protection may require proof of your identification.


### PR DESCRIPTION
Quick one. I put in FoodWorks instead of Sustain Care, because SC isn't really a "thing" yet, legally. I don't know if that's a concern or not. I don't know how to find out. I'd prefer to change it to SC if we can, mostly just to prevent viewer confusion. Assigned @cmatta2 and @prestonaustin to review especially w/r/t this issue.

closes #29